### PR TITLE
Fix column settings persistence

### DIFF
--- a/src/components/datatable/column-settings/ColumnSettingsDialog-v2.tsx
+++ b/src/components/datatable/column-settings/ColumnSettingsDialog-v2.tsx
@@ -158,7 +158,7 @@ export function ColumnSettingsDialogV2({
       }));
 
       // Load saved settings from profile
-      const savedSettings = ColumnSettingsPersistenceV2.getColumnSettings();
+      const savedSettings = await ColumnSettingsPersistenceV2.getColumnSettings();
       const columnSettingsMap: ColumnSettingsMap = savedSettings?.columnSettings || {};
 
       // Initialize with saved settings or extract from current columns
@@ -470,7 +470,7 @@ export function ColumnSettingsDialogV2({
         .map(s => s.colId || '');
 
       // Save to profile
-      const saved = ColumnSettingsPersistenceV2.saveColumnSettings(
+      const saved = await ColumnSettingsPersistenceV2.saveColumnSettings(
         state.columnSettingsMap,
         {
           columnOrder,

--- a/src/services/profile-manager.ts
+++ b/src/services/profile-manager.ts
@@ -2,6 +2,8 @@ import { Profile, ProfileSettings } from '@/types/profile.types';
 import { ProfileStore } from '@/lib/profile-store';
 import { SettingsStore } from '@/stores/settings-store';
 import { SettingsController } from './settings-controller';
+import { extractSettingsFromColDef } from '@/components/datatable/column-settings/conversion-utils';
+import { ColumnSettingsMap } from '@/components/datatable/column-settings/types';
 
 /**
  * ProfileManager handles loading, saving, and switching between profiles
@@ -81,6 +83,23 @@ export class ProfileManager {
     if (!this._activeProfile) return;
 
     const currentSettings = this.settingsController.collectCurrentSettings();
+
+    // Derive column settings map from current column definitions
+    const columnSettingsMap: ColumnSettingsMap = {} as ColumnSettingsMap;
+    if (Array.isArray(currentSettings.custom?.columnDefs)) {
+      currentSettings.custom.columnDefs.forEach((col: any) => {
+        if (col && col.field) {
+          const settings = extractSettingsFromColDef(col, col.field);
+          columnSettingsMap[col.field] = settings;
+        }
+      });
+    }
+
+    if (currentSettings.custom) {
+      currentSettings.custom.columnSettings = columnSettingsMap;
+    } else {
+      currentSettings.custom = { columnSettings: columnSettingsMap };
+    }
     
     const updatedProfile: Profile = {
       ...this._activeProfile,


### PR DESCRIPTION
## Summary
- fix async calls in ColumnSettingsDialogV2
- persist column style settings on profile save

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*